### PR TITLE
msm8953-common: Optimize perfboostsconfig.xml

### DIFF
--- a/msm8953-common/proprietary/vendor/etc/perf/perfboostsconfig.xml
+++ b/msm8953-common/proprietary/vendor/etc/perf/perfboostsconfig.xml
@@ -16,22 +16,14 @@
     <PerfBoost>
 
     <!--app lauch boost-->
-
-        <!-- Type="1", main launch boost of 2sec -->
-
-        <!-- SCHEDBOOST resource opcode, value-->
-        <!-- CPUBOOST_MIN_FREQ LITTLE Core resource opcode, value-->
-        <!-- CPUBOOST_MIN_FREQ BIG resource opcode, value-->
-        <Config
-            Id="0x00001081" Type="1" Enable="true" Timeout="3000"  Target="msm8953"
-            Resources="0x40C00000, 0x1, 0x40800100, 0x7E0, 0x40800000, 0x579" />
-
         <!-- SCHEDBOOST resource opcode, value-->
         <!-- CPUBOOST_MIN_FREQ LITTLE Core resource opcode, value-->
         <!-- SCHED_SPILL_NR_RUN resource opcode, value-->
         <!-- SCHED_RESTRICT_CLUSTER_SPILL resource opcode, value-->
+
+        <!-- Type="1", main launch boost of 2sec -->
         <Config
-            Id="0x00001081" Type="1" Enable="true" Timeout="2000"
+            Id="0x00001081" Type="1" Enable="true" Timeout="2000" Target="msm8953"
             Resources="0x40C00000, 0x1, 0x40800100, 0x690, 0x40C2C000, 0x1, 0x40C34000, 0x0" />
 
     <!--app lauch boost (disabling packing)-->
@@ -39,15 +31,14 @@
 
         <!-- Type="2", launch boost for disable packing 1.5sec -->
         <Config
-            Id="0x00001081" Type="2" Enable="true" Timeout="1500"
+            Id="0x00001081" Type="2" Enable="true" Timeout="1500" Target="msm8953"
             Resources="0x40400000, 0x1" />
 
     <!--resume boost-->
         <!-- SCHEDBOOST resource opcode, value-->
-        <!-- CPUBOOST_MAX_FREQ BIG Core resource opcode, value-->
-        <!-- CPUBOOST_MAX_FREQ LITTLE Core resource opcode, value-->
-        <!-- CPUBOOST_MIN_FREQ BIG Core resource opcode, value-->
         <!-- CPUBOOST_MIN_FREQ LITTLE Core resource opcode, value-->
+        <!-- SCHED_SPILL_NR_RUN resource opcode, value-->
+        <!-- SCHED_RESTRICT_CLUSTER_SPILL resource opcode, value-->
         <!-- CPUBW_MIN_FREQ resource opcode, value-->
         <!-- POWER COLLAPSE resource opcode, value-->
         <!-- STORAGE CLK SCALING resource opcode, value-->
@@ -57,50 +48,36 @@
 
         <Config
             Id="0x00001082" Type="1" Enable="true" Timeout="400" Target="msm8953"
-            Resources="0x40C00000, 0x1, 0x40804000, 0xFFF, 0x40804100, 0xFFF, 0x40800000, 0x8C6,
-                       0x40800100, 0xFFF, 0x41800000, 140, 0x40400000, 0x1, 0x42C10000, 0x1,
-                       0x43000000, 0xFF, 0x43400000, 0xFFFF, 0x4281C000, 0x1" />
+            Resources="0x40C00000, 0x1, 0x40800100, 0x690, 0x40C2C000, 0x1, 0x40C34000, 0x0,
+		       0x41800000, 140, 0x40400000, 0x1, 0x42C10000, 0x1, 0x43000000, 0xFF,
+		       0x43400000, 0xFFFF, 0x4281C000, 0x1" />
 
     <!-- config_enablePerfBoostForAnimation-->
-        <!-- Type="1", Animation boost of 0.6sec -->
         <!-- CPUBOOST_MIN_FREQ LITTLE Core resource opcode, value-->
-        <!-- CPUBOOST_MIN_FREQ BIG Core resource opcode, value-->
-        <Config
-            Id="0x00001083" Enable="true" Timeout="600"  Target="msm8953"
-            Resources="0x40800100, 0x40C, 0x40800000, 0x446" />
 
-        <!-- CPUBOOST_MIN_FREQ LITTLE Core resource opcode, value-->
+        <!-- Type="1", Animation boost of 0.6sec -->
         <Config
-            Id="0x00001083" Enable="true" Timeout="600"
+            Id="0x00001083" Type="1" Enable="true" Timeout="600" Target="msm8953"
             Resources="0x40800100, 0x578" />
 
     <!--Vertical Scroll boost-->
-        <!-- Type="1", Vertical Scroll boost -->
         <!-- CPUBOOST_MIN_FREQ LITTLE Core resource opcode, value -->
-        <!-- CPUBOOST_MIN_FREQ BIG Core resource opcode, value -->
         <!-- SCHEDBOOST resource opcode, value-->
-        <Config
-            Id="0x00001080" Type="1" Enable="true"  Target="msm8953"
-            Resources="0x40800100, 0x40C, 0x40800000, 0x446,0x40C00000, 0x2" />
 
-        <!-- CPUBOOST_MIN_FREQ LITTLE Core resource opcode, value -->
+        <!-- Type="1", Vertical Scroll boost -->
         <Config
-            Id="0x00001080" Type="1" Enable="true"
-            Resources="0x40800100, 0x578" />
+            Id="0x00001080" Type="1" Enable="true" Target="msm8953"
+            Resources="0x40800100, 0x40C, 0x40C00000, 0x2" />
 
     <!--Horizontal Scroll boost-->
-        <!-- Type="2", Horizontal Scroll boost -->
         <!-- CPUBOOST_MIN_FREQ LITTLE Core resource opcode, value -->
-        <!-- CPUBOOST_MIN_FREQ BIG Core resource opcode, value -->
         <!-- SCHEDBOOST resource opcode, value-->
-        <Config
-            Id="0x00001080" Type="2" Enable="true"  Target="msm8953"
-            Resources="0x40800100, 0x40C, 0x40800000, 0x446,0x40C00000, 0x2" />
 
-        <!-- CPUBOOST_MIN_FREQ LITTLE Core resource opcode, value -->
+        <!-- Type="2", Horizontal Scroll boost -->
         <Config
-            Id="0x00001080" Type="2" Enable="true"
-            Resources="0x40800100, 0x578" />
+            Id="0x00001080" Type="2" Enable="true" Target="msm8953"
+            Resources="0x40800100, 0x40C, 0x40C00000, 0x2" />
+
     <!--Pre-Fling boost-->
         <!-- CPUBOOST_MIN_FREQ LITTLE Core resource opcode, value -->
         <!-- CPUBOOST_MIN_FREQ BIG CORE resource opcode, value -->
@@ -108,7 +85,7 @@
         <!-- Type="4", Pre-Fling boost -->
         <Config
             Id="0x00001080" Type="4" Enable="true" Timeout="80" Target="msm8953"
-            Resources="0x40800100, 0x40C, 0x40800000, 0x446,0x40C00000, 0x2"  />
+            Resources="0x40800100, 0x40C, 0x40800000, 0x446, 0x40C00000, 0x2"  />
 
     <!--Rotation latency boost-->
         <!-- SCHEDBOOST resource opcode, value-->
@@ -118,24 +95,17 @@
         <!-- CPUBOOST_MIN_FREQ LITTLE Core resource opcode, value-->
         <!-- Type="", Rotation latency boost -->
         <Config
-            Id="0x00001089" Enable="true" Timeout="1500" Target="sdm632"
+            Id="0x00001089" Enable="true" Timeout="1500" Target="msm8953"
             Resources="0x40C00000, 0x1, 0x40804000, 0xFFF, 0x40804100, 0xFFF, 0x40800000, 0xFFF,
-                       0x40800100,0xFFF" />
-
-        <Config
-            Id="0x00001089" Enable="true" Timeout="1500"
-            Resources="0x40C00000, 0x1, 0x40804100, 0xFFF, 0x40800100, 0xFFF" />
+                       0x40800100, 0xFFF" />
 
     <!--Rotation animation boost-->
         <!-- CPUBOOST_MIN_FREQ LITTLE Core resource opcode, value-->
         <!-- GPU MIN_FREQUENCY resource opcode,value-->
         <!-- Type="", Rotation animation boost -->
         <Config
-            Id="0x00001090" Enable="true" Timeout="1000" Target="sdm632"
-            Resources="0x40800100, 1000, 0x4280C000, 596" />
+            Id="0x00001090" Enable="true" Timeout="1000" Target="msm8953"
+            Resources="0x40800100, 0x40C, 0x4280C000, 596" />
 
-        <Config
-            Id="0x00001090" Enable="true" Timeout="1000"
-            Resources="0x40800100, 1000, 0x4280C000, 596" />
     </PerfBoost>
 </BoostConfigs>


### PR DESCRIPTION
Configuration from the perfboostsconfig.xml is not exactly the best. At each long/fast scroll, the CPU will jump to the highest frequency.

- Fix that problem by editing a CPUBOOST_MIN_FREQ LITTLE Core value for the app lauch boost, 1.6GHz should be enough. Also reduce a timeout to 2000ms. CPU will always jump to the max frequency when we open the application.
- Remove unnecessary boost code without msm8953 boost target.
So, a system should decide which frequency (1GHz - 1.4GHz) to use for short/slow vertical and horizontal scrolls.

Also optimize the code.